### PR TITLE
Rename get_results.py to get_results.sh in README

### DIFF
--- a/grading/grade-tests/README.md
+++ b/grading/grade-tests/README.md
@@ -4,18 +4,18 @@ Extract grades from CSV file provided by Moodle. Use list of IDs in gradebook to
 
 You need to create a file with the Moodle IDs of each student, one per line.
 
-Then for each test, extract the CSV results file from Moodle. Run the `get_grades.py` script using the list file and the CSV results file as arguments.
+Then for each test, extract the CSV results file from Moodle. Run the `get_grades.sh` script using the list file and the CSV results file as arguments.
 
 Sample run:
 
 ```
-./get_grades.py so2-2019-2020_id-list.txt L-A4-S2-SOI-C3-Test\ Laborator\ 4\ -\ Device\ drivere\ în\ Linux-note.csv | cut -d',' -f2
+./get_grades.sh so2-2019-2020_id-list.txt L-A4-S2-SOI-C3-Test\ Laborator\ 4\ -\ Device\ drivere\ în\ Linux-note.csv | cut -d',' -f2
 ```
 
 We use `cut` to only extract the grades and copy paste them in the gradebook. If you want to have an ID to grade mapping (such as for making sure everything works) simply discard the use of `cut`:
 
 ```
-./get_grades.py so2-2019-2020_id-list.txt L-A4-S2-SOI-C3-Test\ Laborator\ 4\ -\ Device\ drivere\ în\ Linux-note.csv
+./get_grades.sh so2-2019-2020_id-list.txt L-A4-S2-SOI-C3-Test\ Laborator\ 4\ -\ Device\ drivere\ în\ Linux-note.csv
 ```
 
 # Grade all - grade_all.sh


### PR DESCRIPTION
The two scripts (get_results.py and get_results.sh) have identical output on the files provided as sample, so all cases that rely on other tools (e.g., `cut`) remain identical. The renaming of the script in the README file was simply missed.

Signed-off-by: Darius Mihai <dariusmihaim@gmail.com>