### PR TITLE
grade_all: Enforce non-alnum chars around numbers

### DIFF
--- a/grading/grade-tests/README.md
+++ b/grading/grade-tests/README.md
@@ -29,7 +29,7 @@ The script expects there could be more than one test to extract grades from, and
  * `exam_numbers` - a list of test numbers to extract grades from, separated by spaces. Exactly one identifier in the list must in the name of a file. For example, to get grades from tests 5, 6, and 7, use "5 6 7".
  * `field_separator` - the field separator used when outputting the grades. For a comma-separated output, use ','.
 
-CSV files are only differentiated by their names, and they must contain exactly one identifier from each `exam_classes` and `exam_numbers`, and must be the only file that matches the pattern - e.g., there cannot be two files named `CA-Test-2-a.csv` and `CA-Test-2-b.csv`, if the values of the fields contain `CA`, and `2`, respectively, since both files match both criteria.
+CSV files are only differentiated by their names, and they must contain exactly one identifier from each `exam_classes` and `exam_numbers`, and must be the only file that matches the pattern - e.g., there cannot be two files named `CA-Test-2-a.csv` and `CA-Test-2-b.csv`, if the values of the fields contain `CA`, and `2`, respectively, since both files match both criteria. The characters around the number must be a non-alphanumeric (e.g., can be a space ' ' or dash '-', but cannot be a letter or number).
 
 The output is a list of values, separated by `field_separator`, where the first value is the username, followed by the grades for each test.
 

--- a/grading/grade-tests/grade_all.sh
+++ b/grading/grade-tests/grade_all.sh
@@ -12,7 +12,6 @@ fi
 
 SCRIPT=$(readlink -f $0)
 SCRIPT_DIR="${SCRIPT%/*}"
-TMP_DIR=$(mktemp -d "${SCRIPT_DIR}/tmp.XXXXXX")
 
 CSV_DIR="${1}"
 CLASSES="${2}"
@@ -24,6 +23,7 @@ if [ ! -d "${CSV_DIR}" ]; then
     exit 2
 fi
 
+TMP_DIR=$(mktemp -d "${SCRIPT_DIR}/tmp.XXXXXX")
 mkdir -p "${TMP_DIR}"
 
 for N in ${EXAM_NUMS}; do
@@ -31,7 +31,7 @@ for N in ${EXAM_NUMS}; do
     rm -f "${RESULT_FILE}"
 
     for S in ${CLASSES}; do
-        CRT_FILE=$(find "${CSV_DIR}" -maxdepth 1 -type f -name "*${S}*${N}*")
+        CRT_FILE=$(find "${CSV_DIR}" -maxdepth 1 -type f -name "*${S}*[^[:alnum:]]${N}[^[:alnum:]]*")
         [ -z "${CRT_FILE}" ] && continue
 
         sed -e '/Nume,Prenume,"Adresă email",State,"Început la",Completat,"Timp încercare"/d' \

--- a/grading/grade-tests/grade_all.sh
+++ b/grading/grade-tests/grade_all.sh
@@ -34,6 +34,11 @@ for N in ${EXAM_NUMS}; do
         CRT_FILE=$(find "${CSV_DIR}" -maxdepth 1 -type f -name "*${S}*[^[:alnum:]]${N}[^[:alnum:]]*")
         [ -z "${CRT_FILE}" ] && continue
 
+        if [ $(echo "${CRT_FILE}" | wc -l) -ne 1 ]; then
+            echo "Too many matches for ${S} / ${N}" >&2
+            exit 2
+        fi
+
         sed -e '/Nume,Prenume,"Adresă email",State,"Început la",Completat,"Timp încercare"/d' \
             -e '/"Medie generală"/d'                                                          \
             -e 's/^\xEF\xBB\xBF//'                                                            \


### PR DESCRIPTION
If the exam numbers could partially overlap (e.g., 5 and 15), the script
could not differentiate between files. The script now searches for files
that have non-alphanumeric characters around the exam number (e.g., spaces).

Signed-off-by: Darius Mihai <dariusmihaim@gmail.com>